### PR TITLE
Allow user specification through environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vim swap files
+.*.swp
+
 # Object files
 *.o
 *.ko

--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ PID   USER     TIME   COMMAND
 
 ## Why reinvent gosu?
 
-This does more or less exactly the same thing as `gosu` but it is only 10kb instead of 1.8MB.
+This does more or less exactly the same thing as [gosu](https://github.com/tianon/gosu)
+but it is only 10kb instead of 1.8MB.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
 # su-exec
 switch user and group id, setgroups and exec
 
-This is a simple tool that will simply execute a program with different
-privileges. The program will not run as a child, like su and sudo, so we
-work around TTY and signal issues.
+## Purpose
 
+This is a simple tool that will simply execute a program with different
+privileges. The program will be exceuted directly and not run as a child,
+like su and sudo does, which avoids TTY and signal issues (see below).
+
+Notice that su-exec depends on being run by the root user, non-root
+users do not have permission to change uid/gid.
+
+## Usage
+
+```shell
+su-exec user-spec command [ arguments... ]
+```
+
+`user-spec` is either a user name (e.g. `nobody`) or user name and group
+name separated with colon (e.g. `nobody:ftp`). Numeric uid/gid values
+can be used instead of names. Example:
+
+```shell
+$ su-exec apache:1000 /usr/sbin/httpd -f /opt/www/httpd.conf
+```
+
+## TTY & parent/child handling
+
+Notice how `su` will make `ps` be a child of a shell while `su-exec`
+just executes `ps` directly.
 
 ```shell
 $ docker run -it --rm alpine:edge su postgres -c 'ps aux'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ can be used instead of names. Example:
 $ su-exec apache:1000 /usr/sbin/httpd -f /opt/www/httpd.conf
 ```
 
+Alternatively `user-spec` can be `-e` or `--env` to enable setting the user/group from environment variables instead:
+
+```shell
+$ export SUID=123
+$ export SGID=456
+$ su-exec --env id
+uid=123 gid=456 groups=456
+```
+
 ## TTY & parent/child handling
 
 Notice how `su` will make `ps` be a child of a shell while `su-exec`

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ privileges. The program will not run as a child, like su and sudo, so we
 work around TTY and signal issues.
 
 
-```console
-$ docker run -it --rm alpine:edge su -c 'ps aux'
+```shell
+$ docker run -it --rm alpine:edge su postgres -c 'ps aux'
 PID   USER     TIME   COMMAND
-    1 root       0:00 ash -c ps aux
-   12 root       0:00 ps aux
-$ docker run -it --rm -v $PWD/su-exec:/sbin/su-exec:ro alpine:edge su-exec  root ps aux
+    1 postgres   0:00 ash -c ps aux
+   12 postgres   0:00 ps aux
+$ docker run -it --rm -v $PWD/su-exec:/sbin/su-exec:ro alpine:edge su-exec postgres ps aux
 PID   USER     TIME   COMMAND
-    1 root       0:00 ps aux
+    1 postgres   0:00 ps aux
 ```
 
 ## Why reinvent gosu?

--- a/su-exec.c
+++ b/su-exec.c
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
 {
 	char *user, *group, **cmdargv;
 	char *end;
+	char *env;
 
 	uid_t uid = getuid();
 	gid_t gid = getgid();
@@ -35,6 +36,24 @@ int main(int argc, char *argv[])
 	group = strchr(user, ':');
 	if (group)
 		*group++ = '\0';
+
+	/* Check for env flag */
+	if (strcmp(user, "-e") == 0 || strcmp(user, "--env") == 0) {
+		/* Clear existing value */
+		user = NULL;
+
+		env = getenv("SUID");
+		if (env != NULL)
+			user = env;
+
+		env = getenv("SGID");
+		if (env != NULL)
+			group = env;
+		
+		if (!user && !group) {
+			err(1, "SUID and SGID environment variables unset");
+		}
+	}
 
 	cmdargv = &argv[2];
 


### PR DESCRIPTION
```
SUID=user SGID=group  su-exec -e command
```

In our use of su-exec in pretty much every container we use, we end up using sh to do this substitution so this cuts out the middleman.